### PR TITLE
Fail `F` when the HTTP response isn't a 2XX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ project/project/
 project/metals.sbt
 
 .env
+
+.idea/

--- a/src/main/scala/dataduggee/DataDuggee.scala
+++ b/src/main/scala/dataduggee/DataDuggee.scala
@@ -74,21 +74,18 @@ object DataDuggee {
 
     def sendMetrics(metrics: NonEmptyList[Metric]): F[String] = {
       val body: Stream[F, String] = codec.encodeMetrics(Stream.emits(metrics.toList))
-
-      val response = for {
+      for {
         req <- POST(body.through(fs2.text.utf8Encode), postMetricsUri, `Content-Type`(MediaType.application.json))
         response <- client.expectOr[String](req)(response => toStringException(response.body))
       } yield response
-      response
     }
 
     def createEvent(event: Event): F[String] = {
       val body = codec.encodeEvent(event)
-      val response = for {
+      for {
         req <- POST(body, postEventUri, `Content-Type`(MediaType.application.json))
         response <- client.expectOr[String](req)(response => toStringException(response.body))
       } yield response
-      response
     }
 
     // TODO: Parse the DataDog error instead of just sending the whole JSON back as a String

--- a/src/main/scala/dataduggee/DataDuggee.scala
+++ b/src/main/scala/dataduggee/DataDuggee.scala
@@ -82,7 +82,7 @@ object DataDuggee {
 
       val response = for {
         req <- POST(body.through(fs2.text.utf8Encode), postMetricsUri, `Content-Type`(MediaType.application.json))
-        response <- client.successful(req)
+        response <- client.successful(req).ensure(new Exception("Failed to send metric to DataDog."))(_ == true)
       } yield response
 
       response.void
@@ -92,7 +92,7 @@ object DataDuggee {
       val body = codec.encodeEvent(event)
       val response = for {
         req <- POST(body, postEventUri, `Content-Type`(MediaType.application.json))
-        resp <- client.successful(req)
+        resp <- client.successful(req).ensure(new Exception("Failed to create event in DataDog."))(_ == true)
       } yield resp
       response.void
     }

--- a/src/main/scala/dataduggee/DataDuggee.scala
+++ b/src/main/scala/dataduggee/DataDuggee.scala
@@ -14,26 +14,26 @@
  * limitations under the License.
  */
 
-package com.filippodeluca.dataduggee
+package com.ovoenergy.dataduggee
 
+import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 
 import cats.data.NonEmptyList
-import cats.implicits._
 import cats.effect._
+import cats.implicits._
 
 import fs2._
-import model._
 import org.http4s.Method._
 import org.http4s.client._
-import org.http4s.syntax.all._
-import org.http4s.headers._
-import org.http4s.client.dsl.Http4sClientDsl
-import org.http4s.{EntityBody, MediaType, Response, Uri}
 import org.http4s.client.blaze.BlazeClientBuilder
-import scala.concurrent.ExecutionContext
+import org.http4s.client.dsl.Http4sClientDsl
+import org.http4s.headers._
+import org.http4s.syntax.all._
+import org.http4s.{MediaType, Response, Uri}
 
-import com.filippodeluca.dataduggee.error.RequestError
+import com.ovoenergy.dataduggee.error.RequestError
+import model._
 
 trait DataDuggee[F[_]] {
   def sendMetrics(metrics: NonEmptyList[Metric]): F[String]
@@ -67,10 +67,10 @@ object DataDuggee {
     def pipeMetrics(
         maxMetrics: Int = 1024,
         maxDelay: FiniteDuration = 10.seconds,
-        maxConcurrrency: Int = 512
+        maxConcurrency: Int = 512
     ): Pipe[F, Metric, String] = { in =>
       in.groupWithin(maxMetrics, maxDelay)
-        .mapAsync(maxConcurrrency) { xs =>
+        .mapAsync(maxConcurrency) { xs =>
           xs.toNel.fold("".pure[F])(sendMetrics)
         }
     }

--- a/src/main/scala/dataduggee/codec.scala
+++ b/src/main/scala/dataduggee/codec.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.filippodeluca.dataduggee
+package com.ovoenergy.dataduggee
 
 import cats.implicits._
 import fs2._

--- a/src/main/scala/dataduggee/model.scala
+++ b/src/main/scala/dataduggee/model.scala
@@ -83,3 +83,11 @@ object model {
     }
   }
 }
+
+object error {
+  abstract class DataDuggeeError extends Exception
+
+  case class RequestError(code: Int, message: String) extends DataDuggeeError {
+    override def getMessage: String = message
+  }
+}

--- a/src/main/scala/dataduggee/model.scala
+++ b/src/main/scala/dataduggee/model.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.filippodeluca.dataduggee
+package com.ovoenergy.dataduggee
 
 import java.time._
 import scala.concurrent.duration.FiniteDuration

--- a/src/test/scala/dataduggee/Arbitraries.scala
+++ b/src/test/scala/dataduggee/Arbitraries.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.filippodeluca.dataduggee
+package com.ovoenergy.dataduggee
 
 import java.time.Instant
 import scala.concurrent.duration._

--- a/src/test/scala/dataduggee/CodecSpec.scala
+++ b/src/test/scala/dataduggee/CodecSpec.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.filippodeluca.dataduggee
+package com.ovoenergy.dataduggee
 
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers

--- a/src/test/scala/dataduggee/DataDuggeeSpec.scala
+++ b/src/test/scala/dataduggee/DataDuggeeSpec.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.filippodeluca.dataduggee
+package com.ovoenergy.dataduggee
 
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers


### PR DESCRIPTION
Hey @filosganga,

I and @ducanhkhu-ovo were having a look at why our call to DataDog didn't fail the `F` and it's because the `client.successful` method returns an `F[Boolean]`, meaning the `F` always succeeds and the boolean will signal the error.

This PR changes the behaviour to what I think we were both expecting: if the HTTP response isn't a 2XX, we'll fail the `F`.

Happy to change if you don't agree.